### PR TITLE
Updated vite to version 6.2.3 because of a security issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "eslint-plugin-react-refresh": "^0.4.19",
         "globals": "^15.15.0",
         "playwright": "^1.51.1",
-        "vite": "^6.2.0",
+        "vite": "^6.2.3",
         "vitest": "^3.0.9",
         "vitest-browser-react": "^0.1.1"
       }
@@ -6417,9 +6417,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.0.tgz",
-      "integrity": "sha512-7dPxoo+WsT/64rDcwoOjk76XHj+TqNTIvHKcuMQ1k4/SeHDaQt5GFAeLYzrimZrMpn/O6DtdI03WUjdxuPM0oQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
+      "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^15.15.0",
     "playwright": "^1.51.1",
-    "vite": "^6.2.0",
+    "vite": "^6.2.3",
     "vitest": "^3.0.9",
     "vitest-browser-react": "^0.1.1"
   }


### PR DESCRIPTION
Updated running version of vite because of a security issue found in the release we were running on, as per the dependabot security issue? 
Found at: https://github.com/ErcModel3/personal-finance-tracker/security/dependabot/1